### PR TITLE
Support for ps3-controller using the shanwan-driver

### DIFF
--- a/src/od-pandora/pandora_input.cpp
+++ b/src/od-pandora/pandora_input.cpp
@@ -285,7 +285,8 @@ static int init_joystick (void)
     printf("Joystick %i : %s\n",cpt,JoystickName[cpt]);
     printf("    Buttons: %i Axis: %i Hats: %i\n",SDL_JoystickNumButtons(Joysticktable[cpt]),SDL_JoystickNumAxes(Joysticktable[cpt]),SDL_JoystickNumHats(Joysticktable[cpt]));
 
-    if (strcmp(JoystickName[cpt],"Sony PLAYSTATION(R)3 Controller") == 0)
+    if (strcmp(JoystickName[cpt],"Sony PLAYSTATION(R)3 Controller") == 0 ||
+            strcmp(JoystickName[cpt],"PLAYSTATION(R)3 Controller") == 0)
     {
       printf("    Found a dualshock controller: Activating workaround.\n");
       IsPS3Controller[cpt] = 1;


### PR DESCRIPTION
Also look for ps3-controller by the default-name from the 'clone support shanwan'-driver, which lacks the 'Sony '-prefix.